### PR TITLE
User schema fix

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -12,12 +12,11 @@ class UserBase(BaseModel):
     username: str = Field(..., min_length=3, max_length=50)
     email: EmailStr
     full_name: Optional[str] = None
-    first_name: Optional[str] = None  # ✅ Add this
-    bio: Optional[str] = None
+    first_name: Optional[str] = None  
     profile_picture_url: Optional[str] = None
-    nickname: Optional[str] = None  # ✅ Add this
-    github_profile_url: Optional[HttpUrl] = None  # ✅ Add this
-    linkedin_profile_url: Optional[HttpUrl] = None  # ✅ Add this
+    nickname: Optional[str] = None 
+    github_profile_url: Optional[HttpUrl] = None 
+    linkedin_profile_url: Optional[HttpUrl] = None  
 
     @validator('username')
     def validate_username(cls, v):
@@ -66,12 +65,12 @@ class UserCreate(UserBase):
 class UserUpdate(BaseModel):
     email: Optional[EmailStr] = None
     full_name: Optional[str] = None
-    first_name: Optional[str] = None  # ✅ Add this
+    first_name: Optional[str] = None  
     bio: Optional[str] = None
     profile_picture_url: Optional[HttpUrl] = None
-    nickname: Optional[str] = None  # ✅ Add this
-    github_profile_url: Optional[HttpUrl] = None  # ✅ Add this
-    linkedin_profile_url: Optional[HttpUrl] = None  # ✅ Add this
+    nickname: Optional[str] = None  
+    github_profile_url: Optional[HttpUrl] = None  
+    linkedin_profile_url: Optional[HttpUrl] = None  
 
     @validator('profile_picture_url', pre=True, always=True)
     def validate_profile_picture_url(cls, v):
@@ -83,7 +82,7 @@ class UserUpdate(BaseModel):
 
 
 class UserResponse(UserBase):
-    id: UUID  # ✅ Use UUID to match DB
+    id: UUID  
     last_login_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
@@ -101,7 +100,7 @@ class UserListResponse(BaseModel):
 
 class LoginRequest(BaseModel):
     username: Optional[str] = None
-    email: Optional[EmailStr] = None  # ✅ Add this
+    email: Optional[EmailStr] = None
     password: str
 
 


### PR DESCRIPTION
🛠️ Fixes: #7 
1. Missing username in test payloads
Error: ValidationError: username field required

Fix: Add username to all UserCreate and UserRegister payloads in tests.

2. Invalid HttpUrl type sent to DB (Url(...))
Error:

graphql
Copy
Edit
invalid input for query argument: expected str, got Url
Fix: In the service layer (e.g., UserService.update), convert HttpUrl fields to str:

python
Copy
Edit
if "github_profile_url" in update_data:
    update_data["github_profile_url"] = str(update_data["github_profile_url"])
if "linkedin_profile_url" in update_data:
    update_data["linkedin_profile_url"] = str(update_data["linkedin_profile_url"])
3. Empty or invalid nicknames not raising validation errors
Error: "" nickname passes, but should fail.

Fix: Improve username/nickname validator:

python
Copy
Edit
if not v or not re.match(r"^[a-zA-Z0-9_-]{3,50}$", v):
    raise ValueError("Nickname must be 3-50 characters and only contain letters, numbers, underscores, or hyphens.")
4. Invalid URLs with unsupported schemes passing validation
Fix: Add check for allowed schemes in profile_picture_url validator:

python
Copy
Edit
if parsed_url.scheme not in ["http", "https"]:
    raise ValueError("Only HTTP/HTTPS URLs are allowed.")
5. UserListResponse missing pagination field
Fix: Return correct structure in /users/ endpoint:

python
Copy
Edit
return UserListResponse(
    items=user_responses,
    pagination=EnhancedPagination(
        currentPage=1,
        totalPages=1,
        totalItems=total_users,
        links=pagination_links
    )
)
