### PR TITLE
Validation Failures and Schema Mismatches in UserCreate, UserResponse…

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -182,12 +182,15 @@ async def list_users(
     
     # Construct the final response with pagination details
     return UserListResponse(
-        items=user_responses,
-        total=total_users,
-        page=skip // limit + 1,
-        size=len(user_responses),
-        links=pagination_links  # Ensure you have appropriate logic to create these links
+    items=user_responses,
+    pagination=EnhancedPagination(
+        currentPage=skip // limit + 1,
+        totalPages=(total_users + limit - 1) // limit,
+        totalItems=total_users,
+        links=pagination_links
     )
+)
+
 
 
 @router.post("/register/", response_model=UserResponse, tags=["Login and Registration"])

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -76,22 +76,31 @@ class UserService:
     @classmethod
     async def update(cls, session: AsyncSession, user_id: UUID, update_data: Dict[str, str]) -> Optional[User]:
         try:
-            # validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
             validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
+
+            for url_field in ['github_profile_url', 'linkedin_profile_url', 'profile_picture_url']:
+                if url_field in validated_data:
+                    validated_data[url_field] = str(validated_data[url_field])
 
             if 'password' in validated_data:
                 validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
-            query = update(User).where(User.id == user_id).values(**validated_data).execution_options(synchronize_session="fetch")
+
+            query = (
+                update(User)
+                .where(User.id == user_id)
+                .values(**validated_data)
+                .execution_options(synchronize_session="fetch")
+            )
             await cls._execute_query(session, query)
             updated_user = await cls.get_by_id(session, user_id)
             if updated_user:
-                session.refresh(updated_user)  # Explicitly refresh the updated user object
+                session.refresh(updated_user)
                 logger.info(f"User {user_id} updated successfully.")
                 return updated_user
             else:
                 logger.error(f"User {user_id} not found after update attempt.")
             return None
-        except Exception as e:  # Broad exception handling for debugging
+        except Exception as e:
             logger.error(f"Error during user update: {e}")
             return None
 

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -64,9 +64,10 @@ async def test_delete_user(async_client, admin_user, admin_token):
 @pytest.mark.asyncio
 async def test_create_user_duplicate_email(async_client, verified_user):
     user_data = {
-        "email": verified_user.email,
-        "password": "AnotherPassword123!",
-    }
+    "username": "new_username",
+    "email": verified_user.email,
+    "password": "AnotherPassword123!"
+}
     response = await async_client.post("/register/", json=user_data)
     assert response.status_code == 400
     assert "Email already exists" in response.json().get("detail", "")

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -10,12 +10,15 @@ pytestmark = pytest.mark.asyncio
 # Test creating a user with valid data
 async def test_create_user_with_valid_data(db_session, email_service):
     user_data = {
+        "username": "valid_user_123",
         "email": "valid_user@example.com",
         "password": "ValidPassword123!",
     }
     user = await UserService.create(db_session, user_data, email_service)
     assert user is not None
     assert user.email == user_data["email"]
+    assert user.username == user_data["username"]
+
 
 # Test creating a user with invalid data
 async def test_create_user_with_invalid_data(db_session, email_service):
@@ -92,12 +95,15 @@ async def test_list_users_with_pagination(db_session, users_with_same_role_50_us
 # Test registering a user with valid data
 async def test_register_user_with_valid_data(db_session, email_service):
     user_data = {
+        "username": "valid_register_user",
         "email": "register_valid_user@example.com",
         "password": "RegisterValid123!",
     }
     user = await UserService.register_user(db_session, user_data, email_service)
     assert user is not None
     assert user.email == user_data["email"]
+    assert user.username == user_data["username"]
+
 
 # Test attempting to register a user with invalid data
 async def test_register_user_with_invalid_data(db_session, email_service):


### PR DESCRIPTION
Fixes Implemented: #9 
Update test cases to include all required fields

Modified test_register_user_with_valid_data and test_create_user_with_valid_data to include a valid username:

python
Copy
Edit
user_data = {
    "username": "valid_user",
    "email": "register_valid_user@example.com",
    "password": "RegisterValid123!"
}
Update UserUpdate schema

Changed github_profile_url and linkedin_profile_url types from HttpUrl to str to match database expectations:

python
Copy
Edit
github_profile_url: Optional[str]
linkedin_profile_url: Optional[str]
Fix UserListResponse construction

Ensure pagination is passed as a single EnhancedPagination object:

python
Copy
Edit
return UserListResponse(
    items=user_responses,
    pagination=EnhancedPagination(
        currentPage=page,
        totalPages=calculated_pages,
        totalItems=total_users,
        links=pagination_links
    )
)
Improve URL validation logic

Modified validate_profile_picture_url() to explicitly reject non-HTTP schemes like ftp.

Add min_length validator for nickname

In UserBase, added:

python
Copy
Edit
@validator('username')
def validate_username(cls, v):
    if len(v) < 3:
        raise ValueError("Username must be at least 3 characters long.")