### PR TITLE
Profile Field Edge Cases: Bio & Profile Picture Updates Failing or In…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ Fixtures:
 
 # Standard library imports
 from builtins import range
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -267,3 +267,11 @@ def user_response_data():
 @pytest.fixture
 def login_request_data():
     return {"email": "john.doe.example.com", "password": "SecurePassword123!"}
+
+@pytest.fixture
+def admin_token(admin_user):
+    access_token_expires = timedelta(minutes=settings.access_token_expire_minutes)
+    return create_access_token(
+        data={"sub": admin_user.email, "role": "ADMIN"},
+        expires_delta=access_token_expires
+    )

--- a/tests/test_api/test_profile_update_edge_cases.py
+++ b/tests/test_api/test_profile_update_edge_cases.py
@@ -1,0 +1,69 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_update_only_bio(async_client, admin_user, admin_token):
+    payload = {"bio": "Updated bio content."}
+    response = await async_client.put(
+        f"/users/{admin_user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 200
+    assert response.json()["bio"] == "Updated bio content."
+    assert response.json()["profile_picture_url"] == admin_user.profile_picture_url
+
+
+@pytest.mark.asyncio
+async def test_update_only_profile_picture(async_client, admin_user, admin_token):
+    new_url = "https://cdn.example.com/images/avatar1.jpg"
+    payload = {"profile_picture_url": new_url}
+    response = await async_client.put(
+        f"/users/{admin_user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 200
+    assert response.json()["profile_picture_url"] == new_url
+    assert response.json()["bio"] == admin_user.bio
+
+
+@pytest.mark.asyncio
+async def test_update_bio_and_profile_picture(async_client, admin_user, admin_token):
+    payload = {
+        "bio": "Full profile update",
+        "profile_picture_url": "https://cdn.example.com/images/avatar2.png"
+    }
+    response = await async_client.put(
+        f"/users/{admin_user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["bio"] == "Full profile update"
+    assert data["profile_picture_url"] == payload["profile_picture_url"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_profile_picture_format(async_client, admin_user, admin_token):
+    payload = {
+        "profile_picture_url": "https://cdn.example.com/docs/resume.pdf"
+    }
+    response = await async_client.put(
+        f"/users/{admin_user.id}",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 422
+    assert "valid image file" in response.text
+
+
+@pytest.mark.asyncio
+async def test_empty_payload_update(async_client, admin_user, admin_token):
+    response = await async_client.put(
+        f"/users/{admin_user.id}",
+        json={},
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code in (400, 422)
+    assert "At least one field must be provided" in response.text


### PR DESCRIPTION
Fix #17 
Schema Validation (UserUpdate in user_schemas.py)

Added a root_validator to ensure at least one field is present in the update payload.

Introduced a custom validator on profile_picture_url to enforce that it ends with .jpg, .jpeg, or .png.

Service Logic (UserService.update)

Ensured exclude_unset=True is respected to avoid overwriting unchanged fields.

Added explicit refresh after update to reflect real-time DB changes in test responses.

Test Cases Added (test_profile_update_edge_cases.py)

test_update_only_bio

test_update_only_profile_picture

test_update_bio_and_profile_picture

test_invalid_profile_picture_format

test_empty_payload_update

These tests validate individual and combined field updates, enforce image URL constraints, and check for required payloads.